### PR TITLE
Add wishlist feature and currency gifting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-KringleCrate is a Minecraft plugin designed to enable a Secret Santa gift exchange among players. It features an opt-in system, recipient assignments, gift submissions, and a redemption system while preserving item metadata such as enchantments, names, and lore.
+KringleCrate is a Minecraft plugin designed to enable a Secret Santa gift exchange among players. It features an opt-in system, recipient assignments, wishlist management, item and currency gift submissions, and a redemption system while preserving item metadata such as enchantments, names, and lore.
 
 ---
 
@@ -10,34 +10,43 @@ KringleCrate is a Minecraft plugin designed to enable a Secret Santa gift exchan
 
 1. **Opt-in System**: Players can opt into the Secret Santa event using a command.
 2. **Recipient Assignment**: Each participant is randomly assigned a recipient.
-3. **Gift Submission**: Players can submit gifts for their recipient while preserving all item metadata.
-4. **Gift Redemption**: Players can redeem their gifts on or after a configurable reveal date.
+3. **Wishlist Support**: Participants can record their gift wishes to help Santas pick the perfect present.
+4. **Gift Submission**: Players can submit item gifts while preserving all metadata or send currency directly through Vault.
+5. **Gift Redemption**: Players can redeem their items and any accumulated currency during the configured redemption period.
 ---
 
 ## Configuration
 
 ### `config.yml`
 ```yaml
-reveal-date: "2024-12-25T00:00:00" # ISO 8601 format for the reveal date
 redemption-start: "2024-12-25T00:00:00"
-redemption-end: "2025-01-01T00:00:00"
+redemption-end: "2025-01-01T23:59:59"
+reveal-date: "2024-12-20T00:00:00"
 ```
 
 ## Commands
-* /kc join 
-  * Description: Opt into the Secret Santa event.
-* /kc reveal
-  Description: Reveal your assigned recipient (after the reveal date).
-* /kc submit
-  Description: Submit a gift for your assigned recipient.
-  /kc redeem
-  Description: Redeem gifts from your Secret Santa.
-  Permissions
-  kringlecrate.override: Allows admins to bypass reveal date restrictions.
+
+* `/kc join`
+  * Opt into the Secret Santa event and create a wishlist profile.
+* `/kc reveal`
+  * Reveal your assigned recipient (after the reveal date or with the `kringlecrate.override` permission).
+* `/kc submit`
+  * Submit the item held in your main hand to your assigned recipient.
+  * `/kc submit currency <amount>` sends Vault currency instead of an item.
+* `/kc wishlist <view|add|remove>`
+  * Manage your gift wishlist once you have joined the event.
+* `/kc redeem`
+  * Redeem stored gifts during the redemption period, including any currency deposits.
+
+### Permissions
+
+* `kringlecrate.override`: Allows admins to bypass reveal date restrictions.
+* `kringlecrate.redeem`: Grants access to the redeem command (enabled for players by default).
 
 ## How It Works
-* Players use `/kc join` to join the event. 
-* The plugin assigns a random recipient to each participant. 
-* Participants can submit a gift using `/kc submit` (before the redemption period begins). 
-* On the reveal date, players can use `/kc reveal` to see their assigned recipient. 
-* Gifts can be redeemed using `/kc redeem` during the redemption period.
+* Players use `/kc join` to participate in the event.
+* The plugin assigns a random recipient to each participant.
+* Participants can request presents with `/kc wishlist add <item>`.
+* Santas submit gifts using `/kc submit` (items) or `/kc submit currency <amount>` (Vault currency) before the redemption period begins.
+* On the reveal date, players can use `/kc reveal` to see their assigned recipient.
+* Gifts, including currency, can be redeemed using `/kc redeem` during the redemption period.

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -4,7 +4,7 @@
   <groupId>me.benrobson</groupId>
   <artifactId>kringlecrate</artifactId>
   <name>kringlecrate</name>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <build>
     <defaultGoal>clean package</defaultGoal>
     <resources>
@@ -50,7 +50,13 @@
     <dependency>
       <groupId>io.papermc.paper</groupId>
       <artifactId>paper-api</artifactId>
-      <version>1.21.1-R0.1-SNAPSHOT</version>
+      <version>1.21.3-R0.1-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.milkbowl.vault</groupId>
+      <artifactId>VaultAPI</artifactId>
+      <version>1.7</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>me.benrobson</groupId>
   <artifactId>kringlecrate</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <packaging>jar</packaging>
 
   <name>kringlecrate</name>
@@ -65,15 +65,15 @@
     <dependency>
       <groupId>io.papermc.paper</groupId>
       <artifactId>paper-api</artifactId>
-      <version>1.21.1-R0.1-SNAPSHOT</version>
+      <version>1.21.3-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>2.8.9</version> <!-- or the latest version -->
-      <scope>compile</scope>
+      <groupId>net.milkbowl.vault</groupId>
+      <artifactId>VaultAPI</artifactId>
+      <version>1.7</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/src/main/java/me/benrobson/kringlecrate/KringleCrate.java
+++ b/src/main/java/me/benrobson/kringlecrate/KringleCrate.java
@@ -9,6 +9,8 @@ public class KringleCrate extends JavaPlugin {
     private GiftConfigManager giftConfigManager;
     private static GiftManager giftManager;
     private static ParticipantManager participantManager;
+    private static WishlistManager wishlistManager;
+    private static EconomyManager economyManager;
 
     private static FormatterUtils formatterUtils;
     private static DateUtils dateUtils;
@@ -20,12 +22,18 @@ public class KringleCrate extends JavaPlugin {
         giftConfigManager = new GiftConfigManager(this);
         giftManager = new GiftManager(this);
         participantManager = new ParticipantManager(this);
+        wishlistManager = new WishlistManager(this);
+        economyManager = new EconomyManager(this);
         formatterUtils = new FormatterUtils(this);
         dateUtils = new DateUtils(this);
 
+        if (!economyManager.setupEconomy()) {
+            getLogger().warning("[KringleCrate] Vault economy not detected. Currency gifts will be disabled.");
+        }
+
         // Register command and tab completer
         getCommand("kc").setExecutor(new CommandManager(this));
-        getCommand("kc").setTabCompleter(new CommandCompleteManager());
+        getCommand("kc").setTabCompleter(new CommandCompleteManager(this));
     }
 
     public static ConfigManager getConfigManager() {
@@ -42,5 +50,13 @@ public class KringleCrate extends JavaPlugin {
 
     public ParticipantManager getParticipantManager() {
         return participantManager;
+    }
+
+    public WishlistManager getWishlistManager() {
+        return wishlistManager;
+    }
+
+    public EconomyManager getEconomyManager() {
+        return economyManager;
     }
 }

--- a/src/main/java/me/benrobson/kringlecrate/commands/join.java
+++ b/src/main/java/me/benrobson/kringlecrate/commands/join.java
@@ -15,7 +15,6 @@ public class join implements CommandExecutor {
 
     private final KringleCrate plugin;
     private final ParticipantManager participantManager;
-    private DateUtils dateUtils;
 
     public join(KringleCrate plugin) {
         this.plugin = plugin;
@@ -46,9 +45,11 @@ public class join implements CommandExecutor {
 
         // Add the player as a participant
         participantManager.addParticipant(playerUUID);
+        plugin.getWishlistManager().initializeWishlist(playerUUID);
 
         // Notify the player
-        player.sendMessage(ChatColor.GREEN + "You have successfully joined the Secret Santa event!");
+        player.sendMessage(ChatColor.GREEN + "You have successfully joined the Secret Santa event!"
+                + ChatColor.AQUA + " Use /kc wishlist add <item> to share your wishes.");
         return true;
     }
 }

--- a/src/main/java/me/benrobson/kringlecrate/commands/redeem.java
+++ b/src/main/java/me/benrobson/kringlecrate/commands/redeem.java
@@ -1,8 +1,8 @@
 package me.benrobson.kringlecrate.commands;
 
 import me.benrobson.kringlecrate.KringleCrate;
-import me.benrobson.kringlecrate.utils.ConfigManager;
 import me.benrobson.kringlecrate.utils.DateUtils;
+import me.benrobson.kringlecrate.utils.EconomyManager;
 import me.benrobson.kringlecrate.utils.GiftManager;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
@@ -11,19 +11,18 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
+import java.text.NumberFormat;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class redeem implements CommandExecutor {
 
     private final KringleCrate plugin;
-    private final ConfigManager configManager;
     private final GiftManager giftManager;
-    private DateUtils dateUtils;
 
     public redeem(KringleCrate plugin) {
         this.plugin = plugin;
-        this.configManager = plugin.getConfigManager();
         this.giftManager = plugin.getGiftManager();
     }
 
@@ -48,24 +47,51 @@ public class redeem implements CommandExecutor {
             return true;
         }
 
-        // Retrieve and deserialize gifts using GiftManager
-        List<ItemStack> gifts = giftManager.getGifts(playerUUID);
-        if (gifts.isEmpty()) {
+        List<GiftManager.GiftRecord> giftRecords = giftManager.getGiftRecords(playerUUID);
+        if (giftRecords.isEmpty()) {
             player.sendMessage(ChatColor.RED + "You have no valid gifts to redeem.");
             plugin.getLogger().info("[REDEEM] No valid gifts found for player UUID: " + playerUUID);
             return true;
         }
 
-        // Check inventory space
+        List<ItemStack> itemGifts = giftRecords.stream()
+                .filter(record -> record.getType() == GiftManager.GiftType.ITEM)
+                .map(GiftManager.GiftRecord::getItem)
+                .collect(Collectors.toList());
+
         int freeSlots = countFreeInventorySlots(player);
-        if (freeSlots < gifts.size()) {
+        if (freeSlots < itemGifts.size()) {
             player.sendMessage(ChatColor.RED + "You don't have enough inventory space for all your gifts.");
-            plugin.getLogger().info("[REDEEM] Insufficient inventory space for player UUID: " + playerUUID + ". Needed: " + gifts.size() + ", Available: " + freeSlots);
+            plugin.getLogger().info("[REDEEM] Insufficient inventory space for player UUID: " + playerUUID + ". Needed: " + itemGifts.size() + ", Available: " + freeSlots);
             return true;
         }
 
-        // Add gifts to inventory and clear the gifts
-        addGiftsToInventoryAndClearConfig(player, gifts, playerUUID);
+        double totalCurrency = giftRecords.stream()
+                .filter(record -> record.getType() == GiftManager.GiftType.CURRENCY)
+                .mapToDouble(GiftManager.GiftRecord::getCurrencyAmount)
+                .sum();
+
+        EconomyManager economyManager = plugin.getEconomyManager();
+        if (totalCurrency > 0 && (economyManager == null || !economyManager.isEconomyAvailable())) {
+            player.sendMessage(ChatColor.RED + "Currency gifts are unavailable right now. Please contact an administrator.");
+            plugin.getLogger().severe("[REDEEM] Currency gifts pending but no economy is available for player UUID: " + playerUUID);
+            return true;
+        }
+
+        addGiftsToInventory(player, itemGifts);
+
+        if (totalCurrency > 0) {
+            boolean deposited = economyManager.deposit(player, totalCurrency);
+            if (!deposited) {
+                player.sendMessage(ChatColor.RED + "An error occurred while redeeming your currency gifts. Please contact an administrator.");
+                return true;
+            }
+            NumberFormat formatter = NumberFormat.getCurrencyInstance();
+            player.sendMessage(ChatColor.GREEN + "You received currency gifts totalling " + ChatColor.GOLD
+                    + formatter.format(totalCurrency) + ChatColor.GREEN + ".");
+        }
+
+        giftManager.clearGifts(playerUUID);
         player.sendMessage(ChatColor.GREEN + "All your gifts have been redeemed!");
         plugin.getLogger().info("[REDEEM] Successfully redeemed gifts for player UUID: " + playerUUID);
 
@@ -80,14 +106,13 @@ public class redeem implements CommandExecutor {
         return freeSlots;
     }
 
-    private void addGiftsToInventoryAndClearConfig(Player player, List<ItemStack> gifts, UUID playerUUID) {
+    private void addGiftsToInventory(Player player, List<ItemStack> gifts) {
         try {
             for (ItemStack gift : gifts) {
                 player.getInventory().addItem(gift);
             }
-            giftManager.clearGifts(playerUUID);  // Use GiftManager's clearGifts method to remove redeemed gifts from the config
         } catch (Exception e) {
-            plugin.getLogger().severe("[REDEEM] Error adding gifts to inventory or updating config for player UUID: " + playerUUID);
+            plugin.getLogger().severe("[REDEEM] Error adding gifts to inventory for player UUID: " + player.getUniqueId());
             plugin.getLogger().severe(e.getMessage());
             e.printStackTrace();
             player.sendMessage(ChatColor.RED + "An error occurred while redeeming your gifts. Please contact an administrator.");

--- a/src/main/java/me/benrobson/kringlecrate/commands/submit.java
+++ b/src/main/java/me/benrobson/kringlecrate/commands/submit.java
@@ -2,6 +2,7 @@ package me.benrobson.kringlecrate.commands;
 
 import me.benrobson.kringlecrate.KringleCrate;
 import me.benrobson.kringlecrate.utils.DateUtils;
+import me.benrobson.kringlecrate.utils.EconomyManager;
 import me.benrobson.kringlecrate.utils.FormatterUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
@@ -10,10 +11,12 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
+import java.text.NumberFormat;
+import java.util.Locale;
+
 public class submit implements CommandExecutor {
 
     private final KringleCrate plugin;
-    private DateUtils dateUtils;
 
     public submit(KringleCrate plugin) {
         this.plugin = plugin;
@@ -29,7 +32,6 @@ public class submit implements CommandExecutor {
         Player player = (Player) sender;
         String playerUUID = player.getUniqueId().toString();
 
-        // Check if submissions are not yet open (before the reveal date)
         if (DateUtils.isBeforeRevealDate()) {
             player.sendMessage(ChatColor.RED + "You cannot submit gifts before the reveal date: "
                     + ChatColor.GOLD + FormatterUtils.getFormattedRevealDate());
@@ -41,10 +43,8 @@ public class submit implements CommandExecutor {
             return true;
         }
 
-        // Debug: Log the player's UUID
         plugin.getLogger().info("Submitting gift for player UUID: " + playerUUID);
 
-        // Check if the player has an assigned recipient
         String assignedPlayer = plugin.getParticipantManager().getAssignedPlayer(playerUUID);
         if (assignedPlayer == null) {
             player.sendMessage(ChatColor.RED + "You do not have an assigned recipient!");
@@ -52,8 +52,11 @@ public class submit implements CommandExecutor {
             return true;
         }
 
-        // Debug: Log the assigned player
         plugin.getLogger().info("Assigned recipient for " + playerUUID + ": " + assignedPlayer);
+
+        if (args.length > 0 && args[0].equalsIgnoreCase("currency")) {
+            return handleCurrencySubmission(player, assignedPlayer, args);
+        }
 
         // Check if the player is holding an item
         ItemStack itemInHand = player.getInventory().getItemInMainHand();
@@ -67,15 +70,56 @@ public class submit implements CommandExecutor {
                 ? itemInHand.getItemMeta().getDisplayName()
                 : itemInHand.getType().name().toLowerCase().replace('_', ' ');
 
-        // Store item details in data.yml
         plugin.getGiftManager().saveGiftSubmission(assignedPlayer, player.getName(), itemInHand);
 
-        // Remove the item from the player's hand
         player.getInventory().setItemInMainHand(null);
 
-        // Send a success message with the item's display name
         player.sendMessage(ChatColor.GREEN + "Your gift has been submitted to your recipient: " + ChatColor.AQUA + itemDisplayName + ChatColor.GREEN + "!");
         plugin.getLogger().info("Gift successfully submitted for recipient UUID: " + assignedPlayer);
+        return true;
+    }
+
+    private boolean handleCurrencySubmission(Player player, String assignedPlayer, String[] args) {
+        EconomyManager economyManager = plugin.getEconomyManager();
+        if (economyManager == null || !economyManager.isEconomyAvailable()) {
+            player.sendMessage(ChatColor.RED + "Currency gifts are currently unavailable. Please contact an administrator.");
+            return true;
+        }
+
+        if (args.length < 2) {
+            player.sendMessage(ChatColor.RED + "Usage: /kc submit currency <amount>");
+            return true;
+        }
+
+        double amount;
+        try {
+            amount = Double.parseDouble(args[1]);
+        } catch (NumberFormatException e) {
+            player.sendMessage(ChatColor.RED + "Invalid amount. Please enter a valid number.");
+            return true;
+        }
+
+        if (amount <= 0) {
+            player.sendMessage(ChatColor.RED + "The amount must be greater than zero.");
+            return true;
+        }
+
+        if (!economyManager.getEconomy().has(player, amount)) {
+            player.sendMessage(ChatColor.RED + "You do not have enough funds to send that amount.");
+            return true;
+        }
+
+        if (!economyManager.withdraw(player, amount)) {
+            player.sendMessage(ChatColor.RED + "An error occurred while withdrawing your funds. Please try again later.");
+            return true;
+        }
+
+        plugin.getGiftManager().saveCurrencyGift(assignedPlayer, player.getName(), amount);
+
+        NumberFormat formatter = NumberFormat.getCurrencyInstance(Locale.getDefault());
+        player.sendMessage(ChatColor.GREEN + "You have gifted " + ChatColor.GOLD + formatter.format(amount)
+                + ChatColor.GREEN + " to your recipient!");
+        plugin.getLogger().info("Currency gift submitted for recipient UUID: " + assignedPlayer + " amount: " + amount);
         return true;
     }
 }

--- a/src/main/java/me/benrobson/kringlecrate/commands/wishlist.java
+++ b/src/main/java/me/benrobson/kringlecrate/commands/wishlist.java
@@ -1,0 +1,111 @@
+package me.benrobson.kringlecrate.commands;
+
+import me.benrobson.kringlecrate.KringleCrate;
+import me.benrobson.kringlecrate.utils.ParticipantManager;
+import me.benrobson.kringlecrate.utils.WishlistManager;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+public class wishlist implements CommandExecutor {
+
+    private final KringleCrate plugin;
+    private final ParticipantManager participantManager;
+    private final WishlistManager wishlistManager;
+
+    public wishlist(KringleCrate plugin) {
+        this.plugin = plugin;
+        this.participantManager = plugin.getParticipantManager();
+        this.wishlistManager = plugin.getWishlistManager();
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "Only players can use this command.");
+            return true;
+        }
+
+        UUID playerUUID = player.getUniqueId();
+        if (!participantManager.getParticipants().contains(playerUUID.toString())) {
+            player.sendMessage(ChatColor.RED + "You must join the Secret Santa event before using a wishlist. Use /kc join.");
+            return true;
+        }
+
+        wishlistManager.initializeWishlist(playerUUID);
+
+        if (args.length == 0 || args[0].equalsIgnoreCase("view")) {
+            sendWishlist(player, playerUUID);
+            return true;
+        }
+
+        String subcommand = args[0].toLowerCase();
+        switch (subcommand) {
+            case "add":
+                return handleAdd(player, playerUUID, args);
+            case "remove":
+                return handleRemove(player, playerUUID, args);
+            default:
+                player.sendMessage(ChatColor.RED + "Usage: /kc wishlist <view|add|remove> [item]");
+                return true;
+        }
+    }
+
+    private boolean handleAdd(Player player, UUID playerUUID, String[] args) {
+        if (args.length < 2) {
+            player.sendMessage(ChatColor.RED + "Usage: /kc wishlist add <item description>");
+            return true;
+        }
+
+        String wish = String.join(" ", Arrays.copyOfRange(args, 1, args.length)).trim();
+        if (wish.isEmpty()) {
+            player.sendMessage(ChatColor.RED + "Wishlist entry cannot be blank.");
+            return true;
+        }
+
+        boolean added = wishlistManager.addItem(playerUUID, wish);
+        if (!added) {
+            player.sendMessage(ChatColor.YELLOW + "That wishlist entry already exists or is invalid.");
+            return true;
+        }
+
+        player.sendMessage(ChatColor.GREEN + "Added to your wishlist: " + ChatColor.GOLD + wish);
+        return true;
+    }
+
+    private boolean handleRemove(Player player, UUID playerUUID, String[] args) {
+        if (args.length < 2) {
+            player.sendMessage(ChatColor.RED + "Usage: /kc wishlist remove <item description>");
+            return true;
+        }
+
+        String wish = String.join(" ", Arrays.copyOfRange(args, 1, args.length)).trim();
+        boolean removed = wishlistManager.removeItem(playerUUID, wish);
+        if (!removed) {
+            player.sendMessage(ChatColor.YELLOW + "No wishlist entry matched that description.");
+            return true;
+        }
+
+        player.sendMessage(ChatColor.GREEN + "Removed from your wishlist: " + ChatColor.GOLD + wish);
+        return true;
+    }
+
+    private void sendWishlist(Player player, UUID playerUUID) {
+        List<String> wishlist = wishlistManager.getWishlist(playerUUID);
+        if (wishlist.isEmpty()) {
+            player.sendMessage(ChatColor.AQUA + "Your wishlist is currently empty. Add items with /kc wishlist add <item>.");
+            return;
+        }
+
+        player.sendMessage(ChatColor.GREEN + "Your wishlist includes:");
+        for (String entry : wishlist) {
+            player.sendMessage(ChatColor.GOLD + " - " + ChatColor.WHITE + entry);
+        }
+    }
+}

--- a/src/main/java/me/benrobson/kringlecrate/utils/CommandCompleteManager.java
+++ b/src/main/java/me/benrobson/kringlecrate/utils/CommandCompleteManager.java
@@ -1,8 +1,10 @@
 package me.benrobson.kringlecrate.utils;
 
+import me.benrobson.kringlecrate.KringleCrate;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -12,21 +14,36 @@ import java.util.List;
 
 public class CommandCompleteManager implements TabCompleter {
 
+    private final KringleCrate plugin;
+
+    public CommandCompleteManager(KringleCrate plugin) {
+        this.plugin = plugin;
+    }
+
     @Override
     public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command,
                                                 @NotNull String alias, @NotNull String[] args) {
         if (args.length == 1) {
-            // Suggest main subcommands
-            return filter(Arrays.asList("join", "reveal", "submit", "redeem"), args[0]);
+            return filter(Arrays.asList("join", "reveal", "submit", "redeem", "wishlist"), args[0]);
         }
 
-        // Return an empty list if no matches
+        if (args.length == 2 && args[0].equalsIgnoreCase("submit")) {
+            return filter(List.of("currency"), args[1]);
+        }
+
+        if (args.length == 2 && args[0].equalsIgnoreCase("wishlist")) {
+            return filter(Arrays.asList("view", "add", "remove"), args[1]);
+        }
+
+        if (args.length == 3 && args[0].equalsIgnoreCase("wishlist") && args[1].equalsIgnoreCase("remove")
+                && sender instanceof Player player) {
+            List<String> wishlist = plugin.getWishlistManager().getWishlist(player.getUniqueId());
+            return filter(wishlist, args[2]);
+        }
+
         return new ArrayList<>();
     }
 
-    /**
-     * Filters suggestions based on the user's input.
-     */
     private List<String> filter(List<String> options, String input) {
         List<String> results = new ArrayList<>();
         for (String option : options) {

--- a/src/main/java/me/benrobson/kringlecrate/utils/CommandManager.java
+++ b/src/main/java/me/benrobson/kringlecrate/utils/CommandManager.java
@@ -5,6 +5,7 @@ import me.benrobson.kringlecrate.commands.join;
 import me.benrobson.kringlecrate.commands.redeem;
 import me.benrobson.kringlecrate.commands.reveal;
 import me.benrobson.kringlecrate.commands.submit;
+import me.benrobson.kringlecrate.commands.wishlist;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -23,7 +24,7 @@ public class CommandManager implements CommandExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (args.length < 1) {
-            sender.sendMessage(ChatColor.RED + "Usage: /kc <join|reveal|submit|redeem>");
+            sender.sendMessage(ChatColor.RED + "Usage: /kc <join|reveal|submit|redeem|wishlist>");
             return true;
         }
 
@@ -38,8 +39,10 @@ public class CommandManager implements CommandExecutor {
                 return new submit(plugin).onCommand(sender, command, label, Arrays.copyOfRange(args, 1, args.length));
             case "redeem":
                 return new redeem(plugin).onCommand(sender, command, label, Arrays.copyOfRange(args, 1, args.length));
+            case "wishlist":
+                return new wishlist(plugin).onCommand(sender, command, label, Arrays.copyOfRange(args, 1, args.length));
             default:
-                sender.sendMessage(ChatColor.RED + "Unknown subcommand. Usage: /kc <join|reveal|submit|redeem>");
+                sender.sendMessage(ChatColor.RED + "Unknown subcommand. Usage: /kc <join|reveal|submit|redeem|wishlist>");
                 return true;
         }
     }

--- a/src/main/java/me/benrobson/kringlecrate/utils/EconomyManager.java
+++ b/src/main/java/me/benrobson/kringlecrate/utils/EconomyManager.java
@@ -1,0 +1,70 @@
+package me.benrobson.kringlecrate.utils;
+
+import me.benrobson.kringlecrate.KringleCrate;
+import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.EconomyResponse;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.plugin.RegisteredServiceProvider;
+
+import java.util.logging.Level;
+
+public class EconomyManager {
+
+    private final KringleCrate plugin;
+    private Economy economy;
+
+    public EconomyManager(KringleCrate plugin) {
+        this.plugin = plugin;
+    }
+
+    public boolean setupEconomy() {
+        if (plugin.getServer().getPluginManager().getPlugin("Vault") == null) {
+            return false;
+        }
+
+        RegisteredServiceProvider<Economy> rsp =
+                plugin.getServer().getServicesManager().getRegistration(Economy.class);
+        if (rsp == null) {
+            return false;
+        }
+
+        economy = rsp.getProvider();
+        return economy != null;
+    }
+
+    public boolean isEconomyAvailable() {
+        return economy != null;
+    }
+
+    public Economy getEconomy() {
+        return economy;
+    }
+
+    public boolean withdraw(OfflinePlayer player, double amount) {
+        if (!isEconomyAvailable()) {
+            return false;
+        }
+
+        EconomyResponse response = economy.withdrawPlayer(player, amount);
+        if (!response.transactionSuccess()) {
+            plugin.getLogger().log(Level.SEVERE,
+                    "[KringleCrate] Failed to withdraw currency: {0}", response.errorMessage);
+            return false;
+        }
+        return true;
+    }
+
+    public boolean deposit(OfflinePlayer player, double amount) {
+        if (!isEconomyAvailable()) {
+            return false;
+        }
+
+        EconomyResponse response = economy.depositPlayer(player, amount);
+        if (!response.transactionSuccess()) {
+            plugin.getLogger().log(Level.SEVERE,
+                    "[KringleCrate] Failed to deposit currency: {0}", response.errorMessage);
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/me/benrobson/kringlecrate/utils/GiftManager.java
+++ b/src/main/java/me/benrobson/kringlecrate/utils/GiftManager.java
@@ -1,6 +1,5 @@
 package me.benrobson.kringlecrate.utils;
 
-import com.google.gson.Gson;
 import me.benrobson.kringlecrate.KringleCrate;
 import org.bukkit.inventory.ItemStack;
 
@@ -8,14 +7,32 @@ import java.util.*;
 
 public class GiftManager {
     private final KringleCrate plugin;
-    private static final Gson gson = new Gson();
 
     public GiftManager(KringleCrate plugin) {
         this.plugin = plugin;
     }
 
     public void saveGiftSubmission(String recipient, String senderName, ItemStack gift) {
-        UUID recipientUUID = UUID.fromString(recipient);
+        Map<String, Object> giftData = new HashMap<>();
+        giftData.put("type", GiftType.ITEM.name());
+        giftData.put("item", gift.clone());
+        giftData.put("sender", senderName);
+
+        appendGift(UUID.fromString(recipient), giftData);
+        plugin.getLogger().info("[KringleCrate] [SAVE] Item gift saved for recipient " + recipient + ": " + giftData);
+    }
+
+    public void saveCurrencyGift(String recipient, String senderName, double amount) {
+        Map<String, Object> giftData = new HashMap<>();
+        giftData.put("type", GiftType.CURRENCY.name());
+        giftData.put("amount", amount);
+        giftData.put("sender", senderName);
+
+        appendGift(UUID.fromString(recipient), giftData);
+        plugin.getLogger().info("[KringleCrate] [SAVE] Currency gift saved for recipient " + recipient + ": " + amount);
+    }
+
+    private void appendGift(UUID recipientUUID, Map<String, Object> giftData) {
         String basePath = "gifts." + recipientUUID;
 
         List<Map<String, Object>> gifts = (List<Map<String, Object>>) plugin.getGiftConfigManager().getConfig().getList(basePath);
@@ -23,38 +40,50 @@ public class GiftManager {
             gifts = new ArrayList<>();
         }
 
-        // Create a map to represent the new gift
-        Map<String, Object> giftData = new HashMap<>();
-        giftData.put("item", gift);
-        giftData.put("sender", senderName);
-
-        // Add the new gift to the list
         gifts.add(giftData);
 
-        // Save the updated list back to the config file
         plugin.getGiftConfigManager().getConfig().set(basePath, gifts);
         plugin.getGiftConfigManager().saveConfigFile();
-
-        plugin.getLogger().info("[KringleCrate] [SAVE] Gift saved for recipient " + recipientUUID + ": " + giftData);
     }
 
-    // Retrieve all gifts for a recipient
-    public List<ItemStack> getGifts(UUID recipientUUID) {
+    public List<GiftRecord> getGiftRecords(UUID recipientUUID) {
         String basePath = "gifts." + recipientUUID;
         List<Map<String, Object>> giftsData = (List<Map<String, Object>>) plugin.getGiftConfigManager().getConfig().getList(basePath);
-        List<ItemStack> gifts = new ArrayList<>();
+        List<GiftRecord> giftRecords = new ArrayList<>();
 
-        if (giftsData != null) {
-            for (Map<String, Object> giftData : giftsData) {
-                Object serializedItem = giftData.get("item");
-                if (serializedItem instanceof ItemStack gift) {
-                    gifts.add(gift);
+        if (giftsData == null) {
+            return giftRecords;
+        }
+
+        for (Map<String, Object> giftData : giftsData) {
+            String typeValue = String.valueOf(giftData.getOrDefault("type", GiftType.ITEM.name()));
+            GiftType type = GiftType.ITEM;
+            try {
+                type = GiftType.valueOf(typeValue.toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException ignored) {
+                plugin.getLogger().warning("[KringleCrate] Unknown gift type '" + typeValue + "' for recipient " + recipientUUID);
+            }
+
+            String sender = (String) giftData.getOrDefault("sender", "Unknown");
+
+            if (type == GiftType.CURRENCY) {
+                Object amountObj = giftData.get("amount");
+                if (amountObj instanceof Number number) {
+                    giftRecords.add(GiftRecord.currency(number.doubleValue(), sender));
                 } else {
-                    plugin.getLogger().warning("[KringleCrate] [REDEEM] Unexpected item format for recipient UUID: " + recipientUUID);
+                    plugin.getLogger().warning("[KringleCrate] Invalid currency data for recipient " + recipientUUID);
                 }
+                continue;
+            }
+
+            Object serializedItem = giftData.get("item");
+            if (serializedItem instanceof ItemStack gift) {
+                giftRecords.add(GiftRecord.item(gift.clone(), sender));
+            } else {
+                plugin.getLogger().warning("[KringleCrate] Unexpected item format for recipient UUID: " + recipientUUID);
             }
         }
-        return gifts;
+        return giftRecords;
     }
 
     public void clearGifts(UUID recipientUUID) {
@@ -64,30 +93,47 @@ public class GiftManager {
         plugin.getLogger().info("[KringleCrate] [CLEAR] Cleared gifts for recipient: " + recipientUUID);
     }
 
-//    // Serialize an ItemStack to a JSON string
-//    private String serializeItemStack(ItemStack item) {
-//        try {
-//            // Convert ItemStack to Map
-//            Map<String, Object> itemMap = item.serialize();
-//            // Serialize the map to JSON
-//            return gson.toJson(itemMap);
-//        } catch (Exception e) {
-//            plugin.getLogger().severe("[SERIALIZE] Could not serialize ItemStack: " + e.getMessage());
-//            return null;
-//        }
-//    }
-//
-//    // Deserialize a JSON string into an ItemStack
-//    public static ItemStack deserializeItemStack(String json) {
-//        try {
-//            // Convert JSON string back to Map
-//            Map<String, Object> itemMap = gson.fromJson(json, Map.class);
-//            // Deserialize the map into an ItemStack
-//            return ItemStack.deserialize(itemMap);
-//        } catch (Exception e) {
-//            System.err.println("[DESERIALIZE] Could not deserialize ItemStack: " + e.getMessage());
-//            e.printStackTrace();
-//            return null;
-//        }
-//    }
+    public enum GiftType {
+        ITEM,
+        CURRENCY
+    }
+
+    public static class GiftRecord {
+        private final GiftType type;
+        private final ItemStack item;
+        private final double currencyAmount;
+        private final String sender;
+
+        private GiftRecord(GiftType type, ItemStack item, double currencyAmount, String sender) {
+            this.type = type;
+            this.item = item;
+            this.currencyAmount = currencyAmount;
+            this.sender = sender;
+        }
+
+        public static GiftRecord item(ItemStack item, String sender) {
+            return new GiftRecord(GiftType.ITEM, item, 0, sender);
+        }
+
+        public static GiftRecord currency(double amount, String sender) {
+            return new GiftRecord(GiftType.CURRENCY, null, amount, sender);
+        }
+
+        public GiftType getType() {
+            return type;
+        }
+
+        public ItemStack getItem() {
+            return item == null ? null : item.clone();
+        }
+
+        public double getCurrencyAmount() {
+            return currencyAmount;
+        }
+
+        public String getSender() {
+            return sender;
+        }
+    }
+
 }

--- a/src/main/java/me/benrobson/kringlecrate/utils/WishlistManager.java
+++ b/src/main/java/me/benrobson/kringlecrate/utils/WishlistManager.java
@@ -1,0 +1,68 @@
+package me.benrobson.kringlecrate.utils;
+
+import me.benrobson.kringlecrate.KringleCrate;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+public class WishlistManager {
+
+    private final KringleCrate plugin;
+
+    public WishlistManager(KringleCrate plugin) {
+        this.plugin = plugin;
+    }
+
+    public void initializeWishlist(UUID playerUUID) {
+        String path = getWishlistPath(playerUUID);
+        if (!plugin.getGiftConfigManager().getConfig().contains(path)) {
+            plugin.getGiftConfigManager().getConfig().set(path, new ArrayList<String>());
+            plugin.getGiftConfigManager().saveConfigFile();
+        }
+    }
+
+    public List<String> getWishlist(UUID playerUUID) {
+        List<String> wishlist = plugin.getGiftConfigManager().getConfig().getStringList(getWishlistPath(playerUUID));
+        return Collections.unmodifiableList(new ArrayList<>(wishlist));
+    }
+
+    public boolean addItem(UUID playerUUID, String wish) {
+        List<String> wishlist = new ArrayList<>(plugin.getGiftConfigManager().getConfig().getStringList(getWishlistPath(playerUUID)));
+        String normalizedWish = wish.trim();
+        if (normalizedWish.isEmpty()) {
+            return false;
+        }
+
+        for (String entry : wishlist) {
+            if (entry.equalsIgnoreCase(normalizedWish)) {
+                return false;
+            }
+        }
+
+        wishlist.add(normalizedWish);
+        plugin.getGiftConfigManager().getConfig().set(getWishlistPath(playerUUID), wishlist);
+        plugin.getGiftConfigManager().saveConfigFile();
+        return true;
+    }
+
+    public boolean removeItem(UUID playerUUID, String wish) {
+        List<String> wishlist = new ArrayList<>(plugin.getGiftConfigManager().getConfig().getStringList(getWishlistPath(playerUUID)));
+        if (wishlist.isEmpty()) {
+            return false;
+        }
+
+        String normalizedWish = wish.trim();
+        boolean removed = wishlist.removeIf(entry -> entry.equalsIgnoreCase(normalizedWish));
+        if (removed) {
+            plugin.getGiftConfigManager().getConfig().set(getWishlistPath(playerUUID), wishlist);
+            plugin.getGiftConfigManager().saveConfigFile();
+        }
+        return removed;
+    }
+
+    private String getWishlistPath(UUID playerUUID) {
+        return "wishlists." + playerUUID;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,8 +1,10 @@
 name: KringleCrate
 main: me.benrobson.kringlecrate.KringleCrate
-version: 1.0.0
+version: 1.1.0
 api-version: 1.21
 description: A Secret Santa plugin for Minecraft.
+softdepend:
+  - Vault
 commands:
   kc:
     description: Main command for KringleCrate.


### PR DESCRIPTION
## Summary
- add per-player wishlists and a `/kc wishlist` command for managing entries
- enable Vault-backed currency gifting alongside existing item submissions and redemptions
- refresh documentation, plugin metadata, and dependencies for the new functionality

## Testing
- `mvn -q -DskipTests package` *(fails: status code: 403 while downloading maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_b_68e39a14c6fc833085040fb7bc189b04

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Wishlist management: add/view/remove wishes via /kc wishlist; join message prompts wishlist setup.
  - Currency gifts: submit currency amounts (via Vault) and redeem as deposits alongside item gifts.
  - Improved tab completion for submit currency and wishlist subcommands.

- Improvements
  - Clearer redemption feedback for items vs. currency with graceful handling when no economy is available.

- Documentation
  - README updated for wishlist, currency support, commands, permissions, and revised event dates.

- Chores
  - Version bumped to 1.1.0; dependencies updated; optional Vault integration declared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->